### PR TITLE
Fix OpenFileDialog "all" filter

### DIFF
--- a/App/Helpers/FileDialogHelper.cs
+++ b/App/Helpers/FileDialogHelper.cs
@@ -155,7 +155,7 @@ internal static class FileDialogHelper
         {
             count++;
             types = new COMDLG_FILTERSPEC[count];
-            types[0] = new COMDLG_FILTERSPEC { pszName = "all", pszSpec = string.Join(';', fileTypeFilter) };
+            types[0] = new COMDLG_FILTERSPEC { pszName = "all", pszSpec = string.Join(';', fileTypeFilter.Select(x => x.Spec)) };
             fileTypeFilter.Select(x => new COMDLG_FILTERSPEC { pszName = x.Name, pszSpec = x.Spec }).ToArray().CopyTo(types, 1);
         }
         dialog.SetFileTypes(count, types);


### PR DESCRIPTION
"all" filter is not correctly implemented when providing multiple spec filter.

**Current behavior**:
![image](https://github.com/xunkong/xunkong/assets/33127223/c39d3691-ad02-418a-99d6-b4fa26cbedb9)

**Expected behavior (after this fix)**:
![correct](https://github.com/xunkong/xunkong/assets/33127223/581637b6-ed76-4784-a507-424460613ba6)
